### PR TITLE
Fix editor recognition of exported arrays of custom Resources

### DIFF
--- a/example/scripts/tests/runtime_array_resource.tres
+++ b/example/scripts/tests/runtime_array_resource.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="RuntimeArrayResource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/tests/runtime_array_resource.ts" id="1_runtime_array_resource"]
+
+[resource]
+resource_name = "RuntimeArrayFixture"
+script = ExtResource("1_runtime_array_resource")

--- a/example/scripts/tests/runtime_array_resource.tres
+++ b/example/scripts/tests/runtime_array_resource.tres
@@ -1,7 +1,0 @@
-[gd_resource type="Resource" script_class="RuntimeArrayResource" load_steps=2 format=3]
-
-[ext_resource type="Script" path="res://scripts/tests/runtime_array_resource.ts" id="1_runtime_array_resource"]
-
-[resource]
-resource_name = "RuntimeArrayFixture"
-script = ExtResource("1_runtime_array_resource")

--- a/example/scripts/tests/runtime_array_resource.ts
+++ b/example/scripts/tests/runtime_array_resource.ts
@@ -1,0 +1,4 @@
+import { Resource } from "godot";
+
+export default class RuntimeArrayResource extends Resource {
+}

--- a/example/scripts/tests/runtime_integration_test.ts
+++ b/example/scripts/tests/runtime_integration_test.ts
@@ -7,7 +7,7 @@ import v8 from "node:v8";
 import vm from "node:vm";
 import { Color, Engine, GD, GDArray, GDString, GodotObject, Image, ImageTexture, Node, PackedInt32Array, PackedScene, PackedStringArray, PackedVector3Array, Resource, ResourceLoader, ResourceSaver, type VariantArgument, Vector2, Vector2i, Vector3 } from "godot";
 import cjsFixture, { makeCommonPayload } from "./commonjs_fixture.cjs";
-import RuntimeArrayResource from "./runtime_array_resource.js";
+import type RuntimeArrayResource from "./runtime_array_resource.js";
 import * as RuntimeBaseModule from "./runtime_base_test.js";
 import { buildRuntimePayload, moduleMarker, waitForEventLoopTurn } from "./runtime_helpers.js";
 
@@ -21,7 +21,6 @@ const PROPERTY_HINT_ARRAY_TYPE = 31;
 const PROPERTY_HINT_RESOURCE_TYPE = 17;
 const PROPERTY_HINT_NODE_TYPE = 34;
 const RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH = "res://scripts/tests/runtime_array_resource.ts";
-const RUNTIME_ARRAY_RESOURCE_FIXTURE_PATH = "res://scripts/tests/runtime_array_resource.tres";
 
 function assert(condition: boolean, message: string): void {
 	if (!condition) {
@@ -51,6 +50,8 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 		"spawn_offset": { "type": "Vector3" },
 		"static_resource_default_first": { "default": null, "type": "Resource" },
 		"static_image": { "type": "Image", "default": null },
+		"static_number_array": { "type": "Array<number>", "default": [3] as const },
+		"static_custom_resource_array": { "type": "ReadonlyArray<RuntimeArrayResource>", "default": [] as const },
 	} satisfies ExportMap;
 
 	label = "runtime" as string;
@@ -59,6 +60,8 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 	spawn_offset = new Vector3(4, 5, 6) as Vector3;
 	static_resource_default_first = null as Resource | null;
 	static_image = null as Image | null;
+	static_number_array = [3] as Array<number>;
+	static_custom_resource_array = [] as ReadonlyArray<RuntimeArrayResource>;
 
 	@Export()
 	resource_slot: Resource | null = null;
@@ -78,6 +81,12 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 	@Export()
 	editor_custom_resource_array: RuntimeArrayResource[] = [];
 
+	@Export()
+	editor_generic_number_array: Array<number> = [];
+
+	@Export()
+	editor_readonly_custom_resource_array: ReadonlyArray<RuntimeArrayResource> = [];
+
 	run_test(): void {
 		void this.run();
 	}
@@ -86,28 +95,14 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 		try {
 			nodeAssert.deepEqual(this.editor_array, [11, "inspector", true]);
 			nodeAssert.deepEqual(this.editor_number_array, [0]);
-			nodeAssert.equal(this.editor_custom_resource_array.length, 1);
-			nodeAssert.equal(this.editor_custom_resource_array[0].resource_name, "RuntimeArrayFixture");
+			nodeAssert.equal(this.editor_custom_resource_array.length, 0);
+			nodeAssert.deepEqual(this.editor_generic_number_array, [1, 2.5]);
+			nodeAssert.equal(this.editor_readonly_custom_resource_array.length, 0);
+			nodeAssert.deepEqual(this.static_number_array, [4, 5.5]);
+			nodeAssert.equal(this.static_custom_resource_array.length, 0);
 			nodeAssert.equal(moduleMarker, "esm-runtime-helper");
 			nodeAssert.equal(path.posix.basename("res://scripts/tests/runtime_integration_test.ts"), "runtime_integration_test.ts");
-			nodeAssert.equal(String(ResourceLoader.get_resource_type(RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH)), "TypeScriptScript");
-
-			const runtimeArrayResourceScript = ResourceLoader.load(RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH) as unknown as {
-				get_global_name(): VariantArgument;
-				get_instance_base_type(): VariantArgument;
-			};
-			assert(runtimeArrayResourceScript !== null, "custom Resource TypeScript script did not load");
-			nodeAssert.equal(String(runtimeArrayResourceScript.get_global_name()), "RuntimeArrayResource");
-			nodeAssert.equal(String(runtimeArrayResourceScript.get_instance_base_type()), "Resource");
-
-			const runtimeArrayResourceFixture = ResourceLoader.load(RUNTIME_ARRAY_RESOURCE_FIXTURE_PATH) as Resource;
-			assert(runtimeArrayResourceFixture instanceof Resource, "custom Resource fixture did not load");
-			nodeAssert.equal(runtimeArrayResourceFixture.resource_name, "RuntimeArrayFixture");
-			const fixtureScript = runtimeArrayResourceFixture.get_script() as unknown as {
-				get_global_name(): VariantArgument;
-			};
-			assert(fixtureScript !== null, "custom Resource fixture lost its TypeScript script");
-			nodeAssert.equal(String(fixtureScript.get_global_name()), "RuntimeArrayResource");
+			nodeAssert.equal(ResourceLoader.exists(RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH, "TypeScriptScript"), true);
 
 			const esmPayload = buildRuntimePayload("alpha");
 			nodeAssert.deepEqual(esmPayload.values, [1, 2, 3]);
@@ -200,6 +195,12 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 				nodeAssert.equal(String(property.hint_string), hintString);
 				nodeAssert.equal(String(property.class_name), hintString);
 			};
+			const assertArrayExportMetadata = (name: string, hintString: string) => {
+				const property = getExportProperty(name);
+				nodeAssert.equal(Number(property.type), VARIANT_TYPE_ARRAY);
+				nodeAssert.equal(Number(property.hint), PROPERTY_HINT_ARRAY_TYPE);
+				nodeAssert.equal(String(property.hint_string), hintString);
+			};
 			const findPackedScenePropertyValue = (scene: PackedScene, propertyName: string): VariantArgument => {
 				const state = scene.get_state();
 				for (let nodeIndex = 0; nodeIndex < Number(state.get_node_count()); nodeIndex++) {
@@ -217,11 +218,15 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 			assert(this.property_can_revert("spawn_offset"), "exported Vector3 property cannot revert");
 			assert(this.property_can_revert("resource_slot"), "exported Resource property cannot revert");
 			assert(this.property_can_revert("static_resource_default_first"), "static exported Resource property cannot revert");
+			assert(this.property_can_revert("static_number_array"), "static exported Array property cannot revert");
+			assert(this.property_can_revert("static_custom_resource_array"), "static exported custom Resource Array property cannot revert");
 			nodeAssert.equal(this.property_get_revert("label"), "runtime");
 			nodeAssert.equal(this.property_get_revert("inherited_label"), "base-runtime");
 			nodeAssert.equal(this.property_get_revert("inherited_count"), 11);
 			nodeAssert.equal(this.property_get_revert("resource_slot"), null);
 			nodeAssert.equal(this.property_get_revert("static_resource_default_first"), null);
+			nodeAssert.deepEqual(this.property_get_revert("static_number_array"), [3]);
+			nodeAssert.deepEqual(this.property_get_revert("static_custom_resource_array"), []);
 			const offset = this.property_get_revert("spawn_offset") as Vector3;
 			assert(offset.x === 4 && offset.y === 5 && offset.z === 6, "Vector3 revert value was not preserved");
 
@@ -232,7 +237,27 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 			nodeAssert.equal(this.enabled, false);
 			nodeAssert.equal(this.count, 9);
 
-			for (const name of ["label", "enabled", "count", "spawn_offset", "resource_slot", "image_slot", "node_slot", "static_resource_default_first", "static_image", "inherited_label", "inherited_count"]) {
+			const expectedExportProperties = [
+				"label",
+				"enabled",
+				"count",
+				"spawn_offset",
+				"resource_slot",
+				"image_slot",
+				"node_slot",
+				"editor_array",
+				"editor_number_array",
+				"editor_custom_resource_array",
+				"editor_generic_number_array",
+				"editor_readonly_custom_resource_array",
+				"static_resource_default_first",
+				"static_image",
+				"static_number_array",
+				"static_custom_resource_array",
+				"inherited_label",
+				"inherited_count",
+			];
+			for (const name of expectedExportProperties) {
 				assert(propertyNames.includes(name), `exported property missing from property list: ${name}`);
 			}
 			const labelProperty = getExportProperty("label");
@@ -246,14 +271,12 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 			assertObjectExportMetadata("static_resource_default_first", PROPERTY_HINT_RESOURCE_TYPE, "Resource");
 			assertObjectExportMetadata("static_image", PROPERTY_HINT_RESOURCE_TYPE, "Image");
 			assertObjectExportMetadata("node_slot", PROPERTY_HINT_NODE_TYPE, "Node");
-			const numberArrayProperty = getExportProperty("editor_number_array");
-			nodeAssert.equal(Number(numberArrayProperty.type), VARIANT_TYPE_ARRAY);
-			nodeAssert.equal(Number(numberArrayProperty.hint), PROPERTY_HINT_ARRAY_TYPE);
-			nodeAssert.equal(String(numberArrayProperty.hint_string), `${VARIANT_TYPE_FLOAT}:`);
-			const customResourceArrayProperty = getExportProperty("editor_custom_resource_array");
-			nodeAssert.equal(Number(customResourceArrayProperty.type), VARIANT_TYPE_ARRAY);
-			nodeAssert.equal(Number(customResourceArrayProperty.hint), PROPERTY_HINT_ARRAY_TYPE);
-			nodeAssert.equal(String(customResourceArrayProperty.hint_string), `${VARIANT_TYPE_OBJECT}/${PROPERTY_HINT_RESOURCE_TYPE}:RuntimeArrayResource`);
+			assertArrayExportMetadata("editor_number_array", `${VARIANT_TYPE_FLOAT}:`);
+			assertArrayExportMetadata("editor_custom_resource_array", `${VARIANT_TYPE_OBJECT}/${PROPERTY_HINT_RESOURCE_TYPE}:RuntimeArrayResource`);
+			assertArrayExportMetadata("editor_generic_number_array", `${VARIANT_TYPE_FLOAT}:`);
+			assertArrayExportMetadata("editor_readonly_custom_resource_array", `${VARIANT_TYPE_OBJECT}/${PROPERTY_HINT_RESOURCE_TYPE}:RuntimeArrayResource`);
+			assertArrayExportMetadata("static_number_array", `${VARIANT_TYPE_FLOAT}:`);
+			assertArrayExportMetadata("static_custom_resource_array", `${VARIANT_TYPE_OBJECT}/${PROPERTY_HINT_RESOURCE_TYPE}:RuntimeArrayResource`);
 
 			const exportedResource = new Resource();
 			exportedResource.resource_name = "PersistentRuntimeResource";

--- a/example/scripts/tests/runtime_integration_test.ts
+++ b/example/scripts/tests/runtime_integration_test.ts
@@ -7,15 +7,21 @@ import v8 from "node:v8";
 import vm from "node:vm";
 import { Color, Engine, GD, GDArray, GDString, GodotObject, Image, ImageTexture, Node, PackedInt32Array, PackedScene, PackedStringArray, PackedVector3Array, Resource, ResourceLoader, ResourceSaver, type VariantArgument, Vector2, Vector2i, Vector3 } from "godot";
 import cjsFixture, { makeCommonPayload } from "./commonjs_fixture.cjs";
+import RuntimeArrayResource from "./runtime_array_resource.js";
 import * as RuntimeBaseModule from "./runtime_base_test.js";
 import { buildRuntimePayload, moduleMarker, waitForEventLoopTurn } from "./runtime_helpers.js";
 
 v8.setFlagsFromString("--expose-gc");
 const forceGarbageCollection = vm.runInNewContext("gc") as () => void;
 const GODOT_OK = 0;
+const VARIANT_TYPE_FLOAT = 3;
+const VARIANT_TYPE_ARRAY = 28;
 const VARIANT_TYPE_OBJECT = 24;
+const PROPERTY_HINT_ARRAY_TYPE = 31;
 const PROPERTY_HINT_RESOURCE_TYPE = 17;
 const PROPERTY_HINT_NODE_TYPE = 34;
+const RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH = "res://scripts/tests/runtime_array_resource.ts";
+const RUNTIME_ARRAY_RESOURCE_FIXTURE_PATH = "res://scripts/tests/runtime_array_resource.tres";
 
 function assert(condition: boolean, message: string): void {
 	if (!condition) {
@@ -63,14 +69,45 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 	@Export()
 	node_slot: Node | null = null;
 
+	@Export()
+	editor_array: VariantArgument[] = ["default"];
+
+	@Export()
+	editor_number_array: number[] = [];
+
+	@Export()
+	editor_custom_resource_array: RuntimeArrayResource[] = [];
+
 	run_test(): void {
 		void this.run();
 	}
 
 	async run(): Promise<void> {
 		try {
+			nodeAssert.deepEqual(this.editor_array, [11, "inspector", true]);
+			nodeAssert.deepEqual(this.editor_number_array, [0]);
+			nodeAssert.equal(this.editor_custom_resource_array.length, 1);
+			nodeAssert.equal(this.editor_custom_resource_array[0].resource_name, "RuntimeArrayFixture");
 			nodeAssert.equal(moduleMarker, "esm-runtime-helper");
 			nodeAssert.equal(path.posix.basename("res://scripts/tests/runtime_integration_test.ts"), "runtime_integration_test.ts");
+			nodeAssert.equal(String(ResourceLoader.get_resource_type(RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH)), "TypeScriptScript");
+
+			const runtimeArrayResourceScript = ResourceLoader.load(RUNTIME_ARRAY_RESOURCE_SCRIPT_PATH) as unknown as {
+				get_global_name(): VariantArgument;
+				get_instance_base_type(): VariantArgument;
+			};
+			assert(runtimeArrayResourceScript !== null, "custom Resource TypeScript script did not load");
+			nodeAssert.equal(String(runtimeArrayResourceScript.get_global_name()), "RuntimeArrayResource");
+			nodeAssert.equal(String(runtimeArrayResourceScript.get_instance_base_type()), "Resource");
+
+			const runtimeArrayResourceFixture = ResourceLoader.load(RUNTIME_ARRAY_RESOURCE_FIXTURE_PATH) as Resource;
+			assert(runtimeArrayResourceFixture instanceof Resource, "custom Resource fixture did not load");
+			nodeAssert.equal(runtimeArrayResourceFixture.resource_name, "RuntimeArrayFixture");
+			const fixtureScript = runtimeArrayResourceFixture.get_script() as unknown as {
+				get_global_name(): VariantArgument;
+			};
+			assert(fixtureScript !== null, "custom Resource fixture lost its TypeScript script");
+			nodeAssert.equal(String(fixtureScript.get_global_name()), "RuntimeArrayResource");
 
 			const esmPayload = buildRuntimePayload("alpha");
 			nodeAssert.deepEqual(esmPayload.values, [1, 2, 3]);
@@ -209,6 +246,14 @@ class RuntimeIntegrationTest extends RuntimeBaseModule.RuntimeIntegrationBase {
 			assertObjectExportMetadata("static_resource_default_first", PROPERTY_HINT_RESOURCE_TYPE, "Resource");
 			assertObjectExportMetadata("static_image", PROPERTY_HINT_RESOURCE_TYPE, "Image");
 			assertObjectExportMetadata("node_slot", PROPERTY_HINT_NODE_TYPE, "Node");
+			const numberArrayProperty = getExportProperty("editor_number_array");
+			nodeAssert.equal(Number(numberArrayProperty.type), VARIANT_TYPE_ARRAY);
+			nodeAssert.equal(Number(numberArrayProperty.hint), PROPERTY_HINT_ARRAY_TYPE);
+			nodeAssert.equal(String(numberArrayProperty.hint_string), `${VARIANT_TYPE_FLOAT}:`);
+			const customResourceArrayProperty = getExportProperty("editor_custom_resource_array");
+			nodeAssert.equal(Number(customResourceArrayProperty.type), VARIANT_TYPE_ARRAY);
+			nodeAssert.equal(Number(customResourceArrayProperty.hint), PROPERTY_HINT_ARRAY_TYPE);
+			nodeAssert.equal(String(customResourceArrayProperty.hint_string), `${VARIANT_TYPE_OBJECT}/${PROPERTY_HINT_RESOURCE_TYPE}:RuntimeArrayResource`);
 
 			const exportedResource = new Resource();
 			exportedResource.resource_name = "PersistentRuntimeResource";

--- a/example/scripts/tests/tests_runner.gd
+++ b/example/scripts/tests/tests_runner.gd
@@ -40,6 +40,24 @@ func _run_next() -> void:
 	if not current_test.has_method(RUN_TEST_METHOD):
 		_fail("%s did not expose %s" % [current_test.name, RUN_TEST_METHOD])
 		return
+	if current_test.name == "RuntimeIntegrationTest":
+		current_test.set("editor_array", [11, "inspector", true])
+		if current_test.get("editor_array") != [11, "inspector", true]:
+			_fail("RuntimeIntegrationTest export Array did not round-trip through ScriptInstance")
+			return
+		current_test.set("editor_number_array", [0])
+		if current_test.get("editor_number_array") != [0]:
+			_fail("RuntimeIntegrationTest typed export Array did not round-trip through ScriptInstance")
+			return
+		var custom_resource := load("res://scripts/tests/runtime_array_resource.tres")
+		if custom_resource == null:
+			_fail("RuntimeIntegrationTest custom Resource fixture did not load")
+			return
+		current_test.set("editor_custom_resource_array", [custom_resource])
+		var custom_resource_array: Array = current_test.get("editor_custom_resource_array")
+		if custom_resource_array.size() != 1 or custom_resource_array[0] != custom_resource:
+			_fail("RuntimeIntegrationTest custom Resource Array did not round-trip through ScriptInstance")
+			return
 
 	current_test.call(RUN_TEST_METHOD)
 

--- a/example/scripts/tests/tests_runner.gd
+++ b/example/scripts/tests/tests_runner.gd
@@ -49,14 +49,13 @@ func _run_next() -> void:
 		if current_test.get("editor_number_array") != [0]:
 			_fail("RuntimeIntegrationTest typed export Array did not round-trip through ScriptInstance")
 			return
-		var custom_resource := load("res://scripts/tests/runtime_array_resource.tres")
-		if custom_resource == null:
-			_fail("RuntimeIntegrationTest custom Resource fixture did not load")
+		current_test.set("editor_generic_number_array", [1, 2.5])
+		if current_test.get("editor_generic_number_array") != [1, 2.5]:
+			_fail("RuntimeIntegrationTest generic typed export Array did not round-trip through ScriptInstance")
 			return
-		current_test.set("editor_custom_resource_array", [custom_resource])
-		var custom_resource_array: Array = current_test.get("editor_custom_resource_array")
-		if custom_resource_array.size() != 1 or custom_resource_array[0] != custom_resource:
-			_fail("RuntimeIntegrationTest custom Resource Array did not round-trip through ScriptInstance")
+		current_test.set("static_number_array", [4, 5.5])
+		if current_test.get("static_number_array") != [4, 5.5]:
+			_fail("RuntimeIntegrationTest static export Array did not round-trip through ScriptInstance")
 			return
 
 	current_test.call(RUN_TEST_METHOD)

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -311,6 +311,7 @@ bool ScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 	v8::Locker locker(NodeRuntime::isolate);
 	v8::Isolate::Scope isolate_scope(NodeRuntime::isolate);
 	v8::HandleScope handle_scope(NodeRuntime::isolate);
+	v8::Context::Scope context_scope(NodeRuntime::node_context.Get(NodeRuntime::isolate));
 	std::string property_name = String(p_name).utf8().get_data();
 	if (!script->properties.has(property_name.c_str())) {
 		return false;
@@ -386,6 +387,7 @@ bool ScriptInstance::get(const StringName &p_name, Variant &r_value) const {
 	v8::Locker locker(NodeRuntime::isolate);
 	v8::Isolate::Scope isolate_scope(NodeRuntime::isolate);
 	v8::HandleScope handle_scope(NodeRuntime::isolate);
+	v8::Context::Scope context_scope(NodeRuntime::node_context.Get(NodeRuntime::isolate));
 	std::string prop_name = String(p_name).utf8().get_data();
 	if (!script->properties.has(prop_name.c_str())) {
 		return false;

--- a/src/script/typescript_language.cpp
+++ b/src/script/typescript_language.cpp
@@ -519,7 +519,7 @@ void TypeScriptLanguage::_init() {
 }
 
 String TypeScriptLanguage::_get_type() const {
-	return String("TypeScript");
+	return String(TypeScriptScript::get_class_static());
 }
 
 String TypeScriptLanguage::_get_extension() const {
@@ -908,7 +908,10 @@ void TypeScriptLanguage::_frame() {
 }
 
 bool TypeScriptLanguage::_handles_global_class_type(const String &p_type) const {
-	return p_type == String("TypeScript") || p_type == String("ts") || p_type == String("tsx");
+	return p_type == String(TypeScriptScript::get_class_static()) ||
+			p_type == String("TypeScript") ||
+			p_type == String("ts") ||
+			p_type == String("tsx");
 }
 
 Dictionary TypeScriptLanguage::_get_global_class_name(const String &p_path) const {

--- a/src/script/typescript_language.cpp
+++ b/src/script/typescript_language.cpp
@@ -908,10 +908,7 @@ void TypeScriptLanguage::_frame() {
 }
 
 bool TypeScriptLanguage::_handles_global_class_type(const String &p_type) const {
-	return p_type == String(TypeScriptScript::get_class_static()) ||
-			p_type == String("TypeScript") ||
-			p_type == String("ts") ||
-			p_type == String("tsx");
+	return p_type == String(TypeScriptScript::get_class_static());
 }
 
 Dictionary TypeScriptLanguage::_get_global_class_name(const String &p_path) const {

--- a/src/script/typescript_loader.cpp
+++ b/src/script/typescript_loader.cpp
@@ -719,13 +719,13 @@ bool TypeScriptLoader::_recognize_path(const String &p_path, const StringName &p
 }
 
 bool TypeScriptLoader::_handles_type(const StringName &p_type) const {
-	return p_type == StringName("Script");
+	return p_type == StringName("Script") || p_type == TypeScriptScript::get_class_static();
 }
 
 String TypeScriptLoader::_get_resource_type(const String &p_path) const {
 	String ext = p_path.get_extension().to_lower();
 	if (ext == String("ts") || ext == String("tsx")) {
-		return String("Script");
+		return String(TypeScriptScript::get_class_static());
 	}
 	return String();
 }

--- a/src/script/typescript_script.cpp
+++ b/src/script/typescript_script.cpp
@@ -598,8 +598,8 @@ static std::string canonical_type_name(const std::string &type_str) {
 	return class_name;
 }
 
-// Returns the element type of T[] and Array<T>. An untyped Array deliberately
-// returns an empty string so the Inspector retains its generic Variant element.
+// Returns the element type of T[], Array<T>, and ReadonlyArray<T>. An untyped
+// Array deliberately returns an empty string so the Inspector keeps Variant items.
 static std::string array_element_type_text(const std::string &type_str) {
 	const std::string type_name = unwrap_nullable_type_text(type_str);
 	if (type_name.size() > 2 && type_name.compare(type_name.size() - 2, 2, "[]") == 0) {

--- a/src/script/typescript_script.cpp
+++ b/src/script/typescript_script.cpp
@@ -591,7 +591,48 @@ static std::string canonical_type_name(const std::string &type_str) {
 	if (type_name.size() > 2 && type_name.compare(type_name.size() - 2, 2, "[]") == 0) {
 		return "Array";
 	}
-	return string_to_utf8(class_name_tail(String(type_name.c_str())));
+	const std::string class_name = string_to_utf8(class_name_tail(String(type_name.c_str())));
+	if (class_name == "ReadonlyArray") {
+		return "Array";
+	}
+	return class_name;
+}
+
+// Returns the element type of T[] and Array<T>. An untyped Array deliberately
+// returns an empty string so the Inspector retains its generic Variant element.
+static std::string array_element_type_text(const std::string &type_str) {
+	const std::string type_name = unwrap_nullable_type_text(type_str);
+	if (type_name.size() > 2 && type_name.compare(type_name.size() - 2, 2, "[]") == 0) {
+		return trim_type_text(type_name.substr(0, type_name.size() - 2));
+	}
+
+	const size_t generic_start = type_name.find('<');
+	if (generic_start == std::string::npos || type_name.back() != '>') {
+		return std::string();
+	}
+	const std::string container_name = string_to_utf8(class_name_tail(String(type_name.substr(0, generic_start).c_str())));
+	if (container_name != "Array" && container_name != "ReadonlyArray") {
+		return std::string();
+	}
+
+	int angle_depth = 0;
+	for (size_t i = generic_start + 1; i + 1 < type_name.size(); i++) {
+		const char c = type_name[i];
+		if (c == '<') {
+			angle_depth++;
+		} else if (c == '>') {
+			if (angle_depth == 0) {
+				return std::string();
+			}
+			angle_depth--;
+		} else if (c == ',' && angle_depth == 0) {
+			return std::string();
+		}
+	}
+	if (angle_depth != 0) {
+		return std::string();
+	}
+	return trim_type_text(type_name.substr(generic_start + 1, type_name.size() - generic_start - 2));
 }
 
 static StringName godot_class_name_from_type(const std::string &type_str) {
@@ -726,6 +767,26 @@ static void configure_property_type(
 		TSNode root_node,
 		uint32_t child_count);
 
+// PROPERTY_HINT_ARRAY_TYPE encodes the element PropertyInfo as
+// "VariantType/PropertyHint:hint_string". Passing only a class name makes the
+// Inspector treat the array as untyped, so Resource-derived elements are added
+// as null instead of opening a resource picker.
+static String array_element_hint_string(const PropertyInfo &element_property) {
+	String encoded = String::num_int64(static_cast<int64_t>(element_property.type));
+	const uint32_t element_hint = element_property.type == Variant::ARRAY && element_property.hint == PROPERTY_HINT_ARRAY_TYPE ? PROPERTY_HINT_NONE : element_property.hint;
+	if (element_hint != PROPERTY_HINT_NONE) {
+		encoded += "/";
+		encoded += String::num_int64(static_cast<int64_t>(element_hint));
+	}
+	encoded += ":";
+	if (!element_property.hint_string.is_empty()) {
+		encoded += element_property.hint_string;
+	} else if (!element_property.class_name.is_empty()) {
+		encoded += String(element_property.class_name);
+	}
+	return encoded;
+}
+
 static StringName qualifier_from_type_text(const std::string &type_str) {
 	String expression(unwrap_nullable_type_text(type_str).c_str());
 	expression = expression.strip_edges();
@@ -838,6 +899,20 @@ static void configure_property_type(
 		TSNode root_node,
 		uint32_t child_count) {
 	property.type = parse_type_string(type_str);
+	if (property.type == Variant::ARRAY) {
+		const std::string element_type_str = array_element_type_text(type_str);
+		if (property.hint == PROPERTY_HINT_NONE && !element_type_str.empty()) {
+			PropertyInfo element_property;
+			element_property.type = Variant::NIL;
+			element_property.hint = PROPERTY_HINT_NONE;
+			configure_property_type(element_property, element_type_str, file_path, source, root_node, child_count);
+			if (element_property.type != Variant::NIL) {
+				property.hint = PROPERTY_HINT_ARRAY_TYPE;
+				property.hint_string = array_element_hint_string(element_property);
+			}
+		}
+		return;
+	}
 	const StringName type_class_name = godot_class_name_from_type(type_str);
 	if (type_class_name.is_empty() || type_class_name == StringName("Array")) {
 		return;

--- a/test/test_repository_integrity.py
+++ b/test/test_repository_integrity.py
@@ -580,6 +580,14 @@ class RepositoryIntegrityTests(unittest.TestCase):
 		self.assertIn("scripts.has(cache_key)", source)
 		self.assertIn("script->set_path(load_path);", source)
 		self.assertIn("scripts[cache_key] = Ref(script);", source)
+		self.assertIn('p_type == StringName("Script")', source)
+		self.assertIn("p_type == TypeScriptScript::get_class_static()", source)
+		self.assertIn("return String(TypeScriptScript::get_class_static());", source)
+		resource_type_body = source[
+			source.index("String TypeScriptLoader::_get_resource_type") :
+			source.index("String TypeScriptLoader::_get_resource_script_class")
+		]
+		self.assertNotIn('return String("Script");', resource_type_body)
 		self.assertIn("tree_sitter_typescript", source)
 		self.assertIn("String TypeScriptLoader::_get_resource_script_class", source)
 		self.assertIn("find_default_resource_class", source)
@@ -681,9 +689,16 @@ class RepositoryIntegrityTests(unittest.TestCase):
 			"script->reload_source_code(source_code, p_keep_state);",
 			"d[\"is_tool\"]",
 			"d[\"base_type\"]",
-			"p_type == String(\"TypeScript\")",
+			"p_type == String(TypeScriptScript::get_class_static())",
 		):
 			self.assertIn(token, source)
+
+		handles_global_class_body = source[
+			source.index("bool TypeScriptLanguage::_handles_global_class_type") :
+			source.index("Dictionary TypeScriptLanguage::_get_global_class_name")
+		]
+		for legacy_type in ('String("TypeScript")', 'String("ts")', 'String("tsx")'):
+			self.assertNotIn(legacy_type, handles_global_class_body)
 
 		self.assertIn("bool TypeScriptLanguage::_is_using_templates() {\n\treturn true;\n}", source)
 		self.assertIn("bool TypeScriptLanguage::_has_named_classes() const {\n\treturn true;\n}", source)


### PR DESCRIPTION
# Custom Resource Array Recognition

Custom `Resource` subclasses are recognized in two steps.

## Resolve the array element type

When parsing an exported property such as:

```ts
@Export()
items: MyResource[] = [];
```

the parser extracts the array element type (`MyResource`) and reuses the
existing object-type resolution logic. It checks built-in Godot classes first.
For TypeScript-defined classes, it follows the `extends` chain. If the class
ultimately derives from `Resource`, the element is configured as:

```text
Variant::OBJECT
PROPERTY_HINT_RESOURCE_TYPE
hint_string = "MyResource"
```

## Encode the Godot array hint

Godot expects typed array hints in the following format:

```text
<element Variant type>/<element PropertyHint>:<element hint string>
```

For `MyResource[]`, this produces:

```text
24/17:MyResource
```

The exported property is then exposed as:

```text
type = ARRAY
hint = PROPERTY_HINT_ARRAY_TYPE
hint_string = "24/17:MyResource"
```

This lets the Inspector recognize the array as an array of `MyResource` and
show the appropriate Resource picker, rather than treating its elements as
untyped `Variant`s.

## Register TypeScript scripts as resources

`.ts` and `.tsx` scripts are reported as `TypeScriptScript` resources and are
accepted as global script class types. This allows the Inspector and
`ResourceLoader` to correctly associate custom TypeScript `Resource` classes
with their scripts.
