### PR TITLE
fix: add missing 'origin' to built-in template entries

### DIFF
--- a/src/script/typescript_language.cpp
+++ b/src/script/typescript_language.cpp
@@ -148,6 +148,7 @@ Dictionary make_template_entry(const String &p_inherit, const String &p_name, co
 	entry["description"] = p_description;
 	entry["content"] = p_content;
 	entry["id"] = p_id;
+	entry["origin"] = 0;
 	return entry;
 }
 

--- a/src/script/typescript_language.cpp
+++ b/src/script/typescript_language.cpp
@@ -38,6 +38,10 @@ constexpr const char *TS_CONTROL_FLOW_WORDS[] = {
 	"finally", "for", "if", "return", "switch", "throw", "try", "while", "yield"
 };
 
+// Mirrors ScriptLanguage::TemplateLocation::TEMPLATE_BUILT_IN, which godot-cpp
+// does not expose as a GDExtension enum.
+constexpr int SCRIPT_TEMPLATE_ORIGIN_BUILT_IN = 0;
+
 bool contains_word(const String &p_word, const char *const *p_words, size_t p_count) {
 	const String word = p_word.strip_edges();
 	for (size_t i = 0; i < p_count; i++) {
@@ -148,7 +152,7 @@ Dictionary make_template_entry(const String &p_inherit, const String &p_name, co
 	entry["description"] = p_description;
 	entry["content"] = p_content;
 	entry["id"] = p_id;
-	entry["origin"] = 0;
+	entry["origin"] = SCRIPT_TEMPLATE_ORIGIN_BUILT_IN;
 	return entry;
 }
 

--- a/test/test_repository_integrity.py
+++ b/test/test_repository_integrity.py
@@ -1103,6 +1103,18 @@ class RepositoryIntegrityTests(unittest.TestCase):
 		self.assertNotIn("script->_get_global_name()", global_class_body)
 		self.assertNotIn("script->get_base_class_name()", global_class_body)
 
+	def test_typescript_builtin_template_entries_include_godot_required_fields(self):
+		source = (ROOT / "src/script/typescript_language.cpp").read_text(encoding="utf-8")
+		match = re.search(r"Dictionary make_template_entry\(.*?\n\}", source, re.DOTALL)
+		self.assertIsNotNone(match)
+		body = match.group(0)
+
+		for key in ("inherit", "name", "description", "content", "id", "origin"):
+			self.assertIn(f'entry["{key}"]', body)
+		self.assertIn("SCRIPT_TEMPLATE_ORIGIN_BUILT_IN", source)
+		self.assertIn('entry["origin"] = SCRIPT_TEMPLATE_ORIGIN_BUILT_IN;', body)
+		self.assertNotIn('entry["origin"] = 0;', body)
+
 	def test_typescript_metadata_parser_resolves_project_imports_like_compiler(self):
 		source = (ROOT / "src/script/typescript_script.cpp").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## PR 说明

### 修复：TypeScript 语言新建脚本时内置模板缺失 origin 字段导致的报错

**问题描述**

在编辑器中新建脚本并将 Script type 切换为 TypeScript 时，会触发如下错误：

```
ERROR: ./core/object/script_language_extension.h:295 - Condition "!d.has("origin")" is true. Continuing.
```

**根因分析**

Godot 引擎在 `ScriptLanguageExtension::get_built_in_templates()`（`core/object/script_language_extension.h`）中会将脚本语言扩展返回的模板字典解析为内部的 `ScriptTemplate`，并对每个字段做硬性校验（`ERR_CONTINUE`）。其中第 295 行校验 `origin` 键，缺失该键的模板会被直接跳过并打印上述错误。

Gode 的 `TypeScriptLanguage::_get_built_in_templates()` 通过辅助函数 `make_template_entry()`（`src/script/typescript_language.cpp:144`）构造模板字典，仅填写了 `inherit / name / description / content / id` 五个键，**遗漏了 `origin` 键**。因此在新建脚本对话框中切换 Script type 为 TypeScript 时，引擎解析到缺失 `origin` 的字典即触发校验失败，两个内置模板（Default / Tool）被全部丢弃，模板下拉列表为空。

**修复方案**

按 Godot 的约定为模板字典补上 `origin` 字段，取值 `TemplateLocation::TEMPLATE_BUILT_IN`（`core/object/script_language.h`，值为 0），表示该模板为脚本语言自带的内置模板：

```cpp
entry["origin"] = 0; // TEMPLATE_BUILT_IN
```

**影响范围**

该问题仅影响编辑器 UI（新建脚本时的内置模板不可用），不影响运行时。修复改动为单行补全，无回归风险。